### PR TITLE
this fix font styles for content created with the visual editor

### DIFF
--- a/css/reset.css
+++ b/css/reset.css
@@ -2,8 +2,6 @@ html,body,div,span,applet,object,iframe,h1,h2,h3,h4,h5,h6,p,blockquote,pre,a,abb
 	margin: 0;
 	padding: 0;
 	border: 0;
-	font-size: 100%;
-	font: inherit;
 	vertical-align: baseline;
 }
 


### PR DESCRIPTION
Hello,

this simple change solves the problems with the content created with the HTML Editors not being correctly stylized.
It only removes the "reset" of the font.
In most cases does not make sense to "inherit" font styles because if you are inside a "p" tag for example, your "b" or "strong" or "i"  tags will have the same style as the "p" tag, that is no bolding and no italic decoration.
Also the "font-size: 100%" was forcing the headers to have wrong sizes.

Kind regards,
Daniel
