### PR TITLE
Fix course content cutting when using topic anchors

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1529,8 +1529,6 @@ body.has_dock #page {
 
 #block-region-side-pre, #block-region-side-post {
 	min-height: 250px;
-	padding-bottom:9999px;
-	margin-bottom:-9999px;
 }
 
 #block-region-side-post {
@@ -1539,7 +1537,6 @@ body.has_dock #page {
 
 #page-content {
 	margin: 0 auto;
-	overflow:hidden;
 }
 
 #region-main a,


### PR DESCRIPTION
Hello,

when using anchors (say, you add an activity to the course and click on "save and go back to course") the course content was being cut in the current section and content above it could not be seem needing a page refresh.

This removes the overflor:hidden of the #page-content element, and also the positive margin and negative padding of the blocks to fix the problem.

Kind regards,
Daniel
